### PR TITLE
Simplify send_to_webhook by removing file checks

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -38,44 +38,11 @@ case "$MODE" in
         return 1 # False, should not ignore
     }
     
-    # Check if a file is currently being written to (has open file handles).
-    # Returns 0 (true) if the file is being written, 1 (false) otherwise.
-    is_file_being_written() {
-        local file_path=$1
-        # Use lsof to check if any process has the file open for writing.
-        # Redirect stderr to suppress errors for files that don't exist or aren't open.
-        if lsof "$file_path" 2>/dev/null | grep -q "[[:space:]].*w"; then
-            return 0 # True, file is being written
-        fi
-        return 1 # False, file is not being written
-    }
-    
     # Function to send file path to the webhook
     send_to_webhook() {
         local file_path=$1
-        local dir base companion
-
-        # Skip files that start with ._
-        base=$(basename "$file_path")
-        if [[ $base == ._* ]]; then
-            echo "Skipping AppleDouble or temp file: $file_path"
-            return
-        fi
-
-        # Skip if a companion ._ file exists for this file
-        dir=$(dirname "$file_path")
-        companion="$dir/._$base"
-        if [[ -e "$companion" ]]; then
-            echo "Skipping $file_path because companion $companion exists (file may be in progress)"
-            return
-        fi
-
         if should_ignore_file "$file_path"; then
             echo "Ignoring file: $file_path"
-            return
-        fi
-        if is_file_being_written "$file_path"; then
-            echo "Skipping file (still being written): $file_path"
             return
         fi
         curl -X POST "http://localhost:8080/import" -H "Content-Type: application/json" -d "{\"OmeroDropbox\":\"$WATCH_NAME\", \"fullPath\":\"$file_path\"}"
@@ -87,15 +54,38 @@ case "$MODE" in
     # avoid scheduling duplicates (per repository behaviour).
     POLL_INTERVAL="${POLL_INTERVAL:-60}"
 
+    # Track file sizes from the previous poll to detect stability.
+    declare -A PREV_SIZES
+
     while true; do
-        find "$WATCHED_DIR" -type f -print0 | while IFS= read -r -d $'\0' file; do
-            # skip directories (find -type f should avoid these, but keep the
-            # check just in case)
+        declare -A NEXT_SIZES
+
+        # Use process substitution to keep the loop in the same shell (so arrays persist).
+        while IFS= read -r -d $'\0' file; do
+            # skip directories (find -type f should avoid these, but keep the check just in case)
             if [[ -d "$file" ]]; then
                 continue
             fi
-            echo "Polling detected file: $file"
-            send_to_webhook "$file"
+
+            # Get current file size; if stat fails, skip.
+            size=$(stat -c%s "$file" 2>/dev/null || echo -1)
+            if [[ "$size" -lt 0 ]]; then
+                continue
+            fi
+
+            prev_size=${PREV_SIZES["$file"]}
+            if [[ -n "$prev_size" && "$prev_size" -eq "$size" ]]; then
+                echo "Stable file (unchanged for $POLL_INTERVAL s): $file"
+                send_to_webhook "$file"
+            fi
+
+            NEXT_SIZES["$file"]="$size"
+        done < <(find "$WATCHED_DIR" -type f -print0)
+
+        # Prepare for next poll: replace PREV_SIZES with NEXT_SIZES
+        PREV_SIZES=()
+        for k in "${!NEXT_SIZES[@]}"; do
+            PREV_SIZES["$k"]="${NEXT_SIZES["$k"]}"
         done
 
         # Sleep before the next poll


### PR DESCRIPTION
Removed file writing checks from send_to_webhook function.

<!-- 
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
